### PR TITLE
Make special casting things cast from the off hand if it is empty and the main hand is not

### DIFF
--- a/src/main/java/miyucomics/hexical/utils/CastingUtils.kt
+++ b/src/main/java/miyucomics/hexical/utils/CastingUtils.kt
@@ -72,7 +72,12 @@ object CastingUtils {
 
 	@JvmStatic
 	fun castSpecial(world: ServerWorld, user: ServerPlayerEntity, hex: List<Iota>, source: SpecializedSource, finale: Boolean): CastingHarness {
-		val harness = IXplatAbstractions.INSTANCE.getHarness(user, Hand.MAIN_HAND)
+		val hand = if(!user.getStackInHand(Hand.MAIN_HAND).isEmpty && user.getStackInHand(Hand.OFF_HAND).isEmpty){
+			Hand.OFF_HAND
+		} else {
+			Hand.MAIN_HAND
+		}
+		val harness = IXplatAbstractions.INSTANCE.getHarness(user, hand)
 		(harness.ctx as CastingContextMinterface).setSpecializedSource(source)
 		(harness.ctx as CastingContextMinterface).setFinale(finale)
 		harness.stack = mutableListOf()


### PR DESCRIPTION
Currently, you can't recharge or read something in your main hand when casting via evocation, this should fix that.