### PR TITLE
Implement hexdoc parsing for hexical:transmuting recipe type

### DIFF
--- a/doc/src/hexdoc_hexical/book/hexical_recipe.py
+++ b/doc/src/hexdoc_hexical/book/hexical_recipe.py
@@ -1,7 +1,37 @@
-from hexdoc.minecraft.assets import ItemWithTexture
-from hexdoc.minecraft.recipe import ItemIngredientList, Recipe
+from typing import Annotated, Any
+from hexdoc.core import ResourceLocation
+from hexdoc.minecraft.recipe import ItemIngredientList, Recipe, ItemResult
+from pydantic import BeforeValidator, model_validator
 
-class TransmutingRecipe(Recipe, type="hexcasting:transmuting"):
-    cost: int = 0
+
+class TransmutingResult(ItemResult):
+    nbt: Any | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_string(cls, value: Any):
+        match value:
+            case str() | ResourceLocation():
+                return {"item": value}
+            case _:
+                return value
+
+
+def _validate_single_item_to_list(value: Any) -> list[Any]:
+    match value:
+        case list():
+            return value  # pyright: ignore[reportUnknownVariableType]
+        case _:
+            return [value]
+
+
+TransmutingResultList = Annotated[
+    list[TransmutingResult],
+    BeforeValidator(_validate_single_item_to_list),
+]
+
+
+class TransmutingRecipe(Recipe, type="hexical:transmuting"):
     input: ItemIngredientList
-    output: list[ItemWithTexture]
+    output: TransmutingResultList
+    cost: int = 0


### PR DESCRIPTION
Note that `hexdoc build` still fails with these changes, since the Jinja templates still need to be properly implemented.