### PR TITLE
Fix sparkles/ping/confetti on server

### DIFF
--- a/src/main/java/miyucomics/hexical/HexicalMain.kt
+++ b/src/main/java/miyucomics/hexical/HexicalMain.kt
@@ -15,6 +15,7 @@ class HexicalMain : ModInitializer {
 		HexicalEvents.init()
 		HexicalIota.init()
 		HexicalItems.init()
+		HexicalParticles.init()
 		HexicalPotions.init()
 		HexicalRecipe.init()
 		HexicalSounds.init()

--- a/src/main/java/miyucomics/hexical/registry/HexicalParticles.kt
+++ b/src/main/java/miyucomics/hexical/registry/HexicalParticles.kt
@@ -10,9 +10,16 @@ import net.minecraft.registry.Registries
 import net.minecraft.registry.Registry
 
 object HexicalParticles {
-	val CONFETTI_PARTICLE: DefaultParticleType = Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("confetti"), FabricParticleTypes.simple(true))
-	val CUBE_PARTICLE: ParticleType<CubeParticleEffect> = Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("cube"), FabricParticleTypes.complex(CubeParticleEffect.Factory))
-	val SPARKLE_PARTICLE: ParticleType<SparkleParticleEffect> = Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("sparkle"), FabricParticleTypes.complex(SparkleParticleEffect.Factory))
+	val CONFETTI_PARTICLE: DefaultParticleType = FabricParticleTypes.simple(true)
+	val CUBE_PARTICLE: ParticleType<CubeParticleEffect> = FabricParticleTypes.complex(CubeParticleEffect.Factory)
+	val SPARKLE_PARTICLE: ParticleType<SparkleParticleEffect> = FabricParticleTypes.complex(SparkleParticleEffect.Factory)
+
+	@JvmStatic
+	fun init() {
+		Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("confetti"), CONFETTI_PARTICLE)
+		Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("cube"), CUBE_PARTICLE)
+		Registry.register(Registries.PARTICLE_TYPE, HexicalMain.id("sparkle"), SPARKLE_PARTICLE)
+	}
 
 	@JvmStatic
 	fun clientInit() {


### PR DESCRIPTION
Casting sparkle/ping (and presumably also confetti) on a server would disconnect clients.

The server would attempt register the particles when the spell was cast. As the registry was frozen this would error and disconnect clients. I guess Kotlin was lazily initializing the properties, you removing lateinit? The issue was hidden in singleplayer because the `HexicalParticles.clientInit` method would implicitly register them.

Noticed this issue in a build using b26a509f18bf3ef9544db0460453659067797e1f but I can reproduce it in the latest commit. I've tested the fix on a server and all seems well. If you want to follow up about anything here or the Hex Casting Discord works for me.