### PR TITLE
Fix off by one error in HexicalItems.randomPlush

### DIFF
--- a/src/main/java/miyucomics/hexical/registry/HexicalItems.kt
+++ b/src/main/java/miyucomics/hexical/registry/HexicalItems.kt
@@ -59,7 +59,7 @@ object HexicalItems {
 
 	@JvmStatic
 	fun randomPlush(): ItemStack {
-		val itemType = listOf(HEXXY, IRISSY, PENTXXY, QUADXXY, THOTHY, FLEXXY)[Random.nextInt(0, 7)]
+		val itemType = listOf(HEXXY, IRISSY, PENTXXY, QUADXXY, THOTHY, FLEXXY).random()
 		return ItemStack(itemType)
 	}
 


### PR DESCRIPTION
This patches a rare crash caused by wandering traders. It's infrequent enough that I don't have positive proof that the fix works, but the change is also very simple so confidence is high.

The range [0,7) is one too long for the list of length six, given zero indexing. This could be fixed by lowering the maximum by one, but using the `random` method is more robust when changing the list.