### PR TITLE
Add check for unbreakable/claimed blocks to breaker spells

### DIFF
--- a/src/main/java/miyucomics/hexical/features/breaking/OpBreakFortune.kt
+++ b/src/main/java/miyucomics/hexical/features/breaking/OpBreakFortune.kt
@@ -7,11 +7,14 @@ import at.petrak.hexcasting.api.casting.getBlockPos
 import at.petrak.hexcasting.api.casting.getPositiveIntUnderInclusive
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.misc.MediaConstants
+import at.petrak.hexcasting.api.mod.HexConfig
+import at.petrak.hexcasting.xplat.IXplatAbstractions
 import net.minecraft.block.Block
 import net.minecraft.enchantment.Enchantments
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.util.math.BlockPos
+import net.minecraft.server.network.ServerPlayerEntity
 
 object OpBreakFortune : SpellAction {
 	override val argc = 2
@@ -25,12 +28,23 @@ object OpBreakFortune : SpellAction {
 	private data class Spell(val pos: BlockPos, val level: Int) : RenderedSpell {
 		override fun cast(env: CastingEnvironment) {
 			val state = env.world.getBlockState(pos)
-			if (state.isAir)
-				return
-			val tool = ItemStack(Items.DIAMOND_PICKAXE)
-			tool.addEnchantment(Enchantments.FORTUNE, level + 1)
-			Block.dropStacks(state, env.world, pos, null, null, tool)
-			env.world.breakBlock(pos, false)
+			val tier = HexConfig.server().opBreakHarvestLevel()
+			if (
+				!state.isAir
+                && state.getHardness(env.world, pos) >= 0f
+                && IXplatAbstractions.INSTANCE.isCorrectTierForDrops(tier, state)
+                && IXplatAbstractions.INSTANCE.isBreakingAllowed(
+                    env.world,
+                    pos,
+                    state,
+                    env.castingEntity as? ServerPlayerEntity
+                )
+			) {
+				val tool = ItemStack(Items.DIAMOND_PICKAXE)
+				tool.addEnchantment(Enchantments.FORTUNE, level + 1)
+				Block.dropStacks(state, env.world, pos, null, null, tool)
+				env.world.breakBlock(pos, false)
+			}
 		}
 	}
 }

--- a/src/main/java/miyucomics/hexical/features/breaking/OpBreakSilk.kt
+++ b/src/main/java/miyucomics/hexical/features/breaking/OpBreakSilk.kt
@@ -6,11 +6,14 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.getBlockPos
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.misc.MediaConstants
+import at.petrak.hexcasting.api.mod.HexConfig
+import at.petrak.hexcasting.xplat.IXplatAbstractions
 import net.minecraft.block.Block
 import net.minecraft.enchantment.Enchantments
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.util.math.BlockPos
+import net.minecraft.server.network.ServerPlayerEntity
 
 object OpBreakSilk : SpellAction {
 	override val argc = 1
@@ -23,12 +26,23 @@ object OpBreakSilk : SpellAction {
 	private data class Spell(val pos: BlockPos) : RenderedSpell {
 		override fun cast(env: CastingEnvironment) {
 			val state = env.world.getBlockState(pos)
-			if (state.isAir)
-				return
-			val tool = ItemStack(Items.DIAMOND_PICKAXE)
-			tool.addEnchantment(Enchantments.SILK_TOUCH, 1)
-			Block.dropStacks(state, env.world, pos, null, null, tool)
-			env.world.breakBlock(pos, false)
+			val tier = HexConfig.server().opBreakHarvestLevel()
+			if (
+				!state.isAir
+                && state.getHardness(env.world, pos) >= 0f
+                && IXplatAbstractions.INSTANCE.isCorrectTierForDrops(tier, state)
+                && IXplatAbstractions.INSTANCE.isBreakingAllowed(
+                    env.world,
+                    pos,
+                    state,
+                    env.castingEntity as? ServerPlayerEntity
+                )
+			) {
+				val tool = ItemStack(Items.DIAMOND_PICKAXE)
+				tool.addEnchantment(Enchantments.SILK_TOUCH, 1)
+				Block.dropStacks(state, env.world, pos, null, null, tool)
+				env.world.breakBlock(pos, false)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #90 by implementing the same is-this-breakable checks used in the base mod's Break Block spell. This also means that the specialized breakers can no longer destroy blocks in other people's claims, or blocks with a mining level higher than diamond.