### PR TITLE
GBlink now checks if destination is within the world

### DIFF
--- a/src/main/java/miyucomics/hexical/features/misc_actions/OpGreaterBlink.kt
+++ b/src/main/java/miyucomics/hexical/features/misc_actions/OpGreaterBlink.kt
@@ -36,6 +36,7 @@ object OpGreaterBlink : SpellAction {
 		val destination = caster.pos.add(worldOffset)
 		if (!HexConfig.server().canTeleportInThisDimension(env.world.registryKey))
 			throw MishapBadLocation(destination, "bad_dimension")
+		env.assertVecInWorld(destination)
 
 		if (worldOffset.length() > 128)
 			throw MishapBadLocation(destination)


### PR DESCRIPTION
This check is unnecessary in Displace as it can safely be assumed that the circle made of blocks that you place is probably in the world