### PR TITLE
Fix charmed item media bar display

### DIFF
--- a/src/main/java/miyucomics/hexical/mixin/ItemStackMixin.java
+++ b/src/main/java/miyucomics/hexical/mixin/ItemStackMixin.java
@@ -23,8 +23,8 @@ public class ItemStackMixin {
 		NbtCompound nbt = stack.getNbt();
 		if (nbt != null && nbt.contains("charmed")) {
 			NbtCompound charm = nbt.getCompound("charmed");
-			int maxMedia = charm.getInt("max_media");
-			int media = charm.getInt("media");
+			long maxMedia = charm.getLong("max_media");
+            long media = charm.getLong("media");
 			cir.setReturnValue(MediaHelper.mediaBarWidth(media, maxMedia));
 		}
 	}


### PR DESCRIPTION
Media bar of Charmed Item may display incorrectly if media in charm item bigger than `Integer.MAX_VALUE`